### PR TITLE
Added HealthPack and HealthPackSpawner prefabs

### DIFF
--- a/Assets/Prefabs/Enemy.prefab
+++ b/Assets/Prefabs/Enemy.prefab
@@ -28,7 +28,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3515135418602185387}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 5.62, y: 0.28, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -105,6 +105,8 @@ MonoBehaviour:
   jumpForce: 7
   maxVelocity: 3
   collisionTimeThreshold: 0.3
+  damage: 2
+  _gameHandler: {fileID: 0}
 --- !u!61 &843256151468167299
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/EnemySpawner.prefab
+++ b/Assets/Prefabs/EnemySpawner.prefab
@@ -1,0 +1,49 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4963767035382682425
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4963767035382682424}
+  - component: {fileID: 4963767035382682427}
+  m_Layer: 0
+  m_Name: EnemySpawner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4963767035382682424
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4963767035382682425}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.1502327, y: -1.9628389, z: -0.3043302}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4963767035382682427
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4963767035382682425}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d7f6f15a44d3764fb5387258f7d78a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _enemy: {fileID: 3515135418602185387, guid: 08bd43fe8a362cc439d67fac95001486, type: 3}
+  _spawnTime: 20
+  _maxEnemies: 3

--- a/Assets/Prefabs/HealthPack.prefab
+++ b/Assets/Prefabs/HealthPack.prefab
@@ -1,0 +1,149 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1371457863852944953
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1371457863852944952}
+  - component: {fileID: 1333366328866238930}
+  - component: {fileID: 8681814369731663567}
+  - component: {fileID: 4171363831425783761}
+  - component: {fileID: 3068873606322883568}
+  m_Layer: 0
+  m_Name: HealthPack
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1371457863852944952
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1371457863852944953}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1333366328866238930
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1371457863852944953}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!50 &8681814369731663567
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1371457863852944953}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!61 &4171363831425783761
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1371457863852944953}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!114 &3068873606322883568
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1371457863852944953}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c56fbc5178885d54395254ac9bad89b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _healAmount: 5

--- a/Assets/Prefabs/HealthPackSpawner.prefab
+++ b/Assets/Prefabs/HealthPackSpawner.prefab
@@ -1,0 +1,49 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6841706197914159304
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6841706197914159307}
+  - component: {fileID: 6841706197914159306}
+  m_Layer: 0
+  m_Name: HealthPackSpawner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6841706197914159307
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6841706197914159304}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.3, y: -1.37, z: -0.35659853}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6841706197914159306
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6841706197914159304}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 03a0b9a5a85af894493d051a12a68a86, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _healthPack: {fileID: 573639845973570565, guid: 4836cc67471aac248b6787268303ed07, type: 3}
+  _spawnTime: 10
+  _maxHealthPacks: 1

--- a/Assets/Scripts/EnemyMovement.cs
+++ b/Assets/Scripts/EnemyMovement.cs
@@ -86,4 +86,10 @@ public class EnemyMovement : GroundDetectionEntity
             collision.gameObject.GetComponent<PlayerHealth>().DamagePlayer(damage, true);
         }
     }
+
+    public void InitializeEnemy(Transform playerForm, GameHandler gameHandler)
+    {
+        playerTransform = playerForm;
+        _gameHandler = gameHandler;
+    }
 }

--- a/Assets/Scripts/EnemySpawner.cs
+++ b/Assets/Scripts/EnemySpawner.cs
@@ -1,0 +1,48 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class EnemySpawner : MonoBehaviour
+{
+    [SerializeField] private GameHandler _gameHandler;
+    [SerializeField] private Transform _playerTransform;
+    // The Enemy prefab that should be spawned.
+    [SerializeField] private GameObject _enemy;
+    // How many seconds between spawns.
+    [SerializeField] private float _spawnTime = 10f;
+    [SerializeField] private bool _spawnOnStart = false;
+    private float _timeToNextSpawn;
+    // How many Enemies can be spawned at this point at a time.
+    [SerializeField] private int _maxEnemies = 1;
+
+    void Start()
+    {
+        if (_spawnOnStart) SpawnEnemy();
+        else _timeToNextSpawn = _spawnTime;
+    }
+    
+    void Update()
+    {
+        // If there are less Enemies than the max amount, spawn a new one.
+        if (transform.childCount < _maxEnemies)
+        {
+            _timeToNextSpawn -= Time.deltaTime;
+            if (_timeToNextSpawn <= 0)
+            {
+                SpawnEnemy();
+            }
+        }
+    }
+    
+    private void SpawnEnemy()
+    {
+        Debug.Log("Enemy has been spawned.");
+        // Make the Enemy as child of this EnemySpawner.
+        GameObject enemy = Instantiate(_enemy);
+        enemy.transform.position = transform.position;
+        enemy.transform.parent = transform;
+        enemy.GetComponent<EnemyMovement>().InitializeEnemy(_playerTransform, _gameHandler);
+        enemy.SetActive(true);
+        _timeToNextSpawn = _spawnTime;
+    }
+}

--- a/Assets/Scripts/HealthPack.cs
+++ b/Assets/Scripts/HealthPack.cs
@@ -1,0 +1,39 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class HealthPack : MonoBehaviour
+{
+    [SerializeField] private float _healAmount = 5f;
+    
+    void OnCollisionStay2D(Collision2D collision)
+    {
+
+        if (collision.gameObject.tag == "Player")
+        {
+            // I thought this would ignore the physics collision so there wouldn't be
+            // a stutter when the player picked up the HealthPack, but it only ignores future collisions.
+            // Physics2D.IgnoreCollision(collision.gameObject.GetComponent<Collider2D>(), GetComponent<Collider2D>());
+            collision.gameObject.GetComponent<PlayerHealth>().HealPlayer(_healAmount);
+            // Destroy the HealPack after the player gets it.
+            Destroy(gameObject);
+        }
+    }
+    
+    /*
+    // To make the player not collide physically with the HealthPack,
+    // use this function instead of OnCollisionStay2D. Put the script instead on a child with a
+    // BoxCollider2D set to trigger. Then set the parent's layer to one that doesn't collide with the player.
+    void OnTriggerEnter2D(Collider2D collided)
+    {
+        Debug.Log("Collided with HealthPack!");
+        if (collided.gameObject.tag == "Player")
+        {
+            collided.gameObject.GetComponent<PlayerHealth>().HealPlayer(_healAmount);
+            // Destroy the HealPack after the player gets it.
+            //Destroy(gameObject);
+            Destroy(transform.parent.gameObject);
+        }
+    }
+    */
+}

--- a/Assets/Scripts/HealthPackSpawner.cs
+++ b/Assets/Scripts/HealthPackSpawner.cs
@@ -12,10 +12,10 @@ public class HealthPackSpawner : MonoBehaviour
     // How many HealthPacks can be on the map at a time in this spawn location.
     // We might just want to have this always be 1.
     [SerializeField] private int _maxHealthPacks = 1;
-
+    
     void Start()
     {
-        spawnHealthPack();
+        SpawnHealthPack();
     }
     
     void Update()
@@ -26,16 +26,18 @@ public class HealthPackSpawner : MonoBehaviour
             _timeToNextSpawn -= Time.deltaTime;
             if (_timeToNextSpawn <= 0)
             {
-                spawnHealthPack();
+                SpawnHealthPack();
             }
         }
     }
     
-    private void spawnHealthPack()
+    private void SpawnHealthPack()
     {
         Debug.Log("Health pack has been spawned.");
         // Make the HealthPack as child of this HealthPackSpawner.
-        Instantiate(_healthPack, transform);
+        GameObject healthPack = Instantiate(_healthPack);
+        healthPack.transform.position = transform.position;
+        healthPack.transform.parent = transform;
         _timeToNextSpawn = _spawnTime;
     }
 }

--- a/Assets/Scripts/HealthPackSpawner.cs
+++ b/Assets/Scripts/HealthPackSpawner.cs
@@ -1,0 +1,41 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class HealthPackSpawner : MonoBehaviour
+{
+    // The HealthPack prefab that should be spawned.
+    [SerializeField] private GameObject _healthPack;
+    // How many seconds between HealthPack spawns.
+    [SerializeField] private float _spawnTime = 10f;
+    private float _timeToNextSpawn;
+    // How many HealthPacks can be on the map at a time in this spawn location.
+    // We might just want to have this always be 1.
+    [SerializeField] private int _maxHealthPacks = 1;
+
+    void Start()
+    {
+        spawnHealthPack();
+    }
+    
+    void Update()
+    {
+        // If there are less HealthPacks than the max amount, spawn a new one.
+        if (transform.childCount < _maxHealthPacks)
+        {
+            _timeToNextSpawn -= Time.deltaTime;
+            if (_timeToNextSpawn <= 0)
+            {
+                spawnHealthPack();
+            }
+        }
+    }
+    
+    private void spawnHealthPack()
+    {
+        Debug.Log("Health pack has been spawned.");
+        // Make the HealthPack as child of this HealthPackSpawner.
+        Instantiate(_healthPack, transform);
+        _timeToNextSpawn = _spawnTime;
+    }
+}

--- a/Assets/Scripts/PlayerHealth.cs
+++ b/Assets/Scripts/PlayerHealth.cs
@@ -32,10 +32,6 @@ public class PlayerHealth : MonoBehaviour
     void Update()
     {
 	    _hpSlider.value = _playerHealth;
-    }
-
-    void FixedUpdate()
-    {
 	    if (_immune)
 	    {
 		    _immuneTime = _immuneTime - Time.deltaTime;
@@ -53,7 +49,7 @@ public class PlayerHealth : MonoBehaviour
 		    }
 	    }
     }
-    
+
     public void makePlayerImmune()
     {
 	    _immune = true;


### PR DESCRIPTION
HealthPackSpawner spawns a new HealthPack at a set rate until a max limit on the amount of HealthPacks is reached. When the player collides with a HealthPack, they are healed, and the HealthPack is destroyed. Right now, the player physically collides with HealthPacks. If we want to change that, we can add a child to HealthPack with a Trigger collider on it, then put the script on the child. Then, we would set the parent to a layer that doesn't collide with the player. I have more details about this in a comment on the HealthPack script. Closes #53.
Also added a very basic EnemySpawner class and prefab that just spawns enemies according to a time interval for #51. We need to add a lot more functionality that makes it detect collision with the player, etc. I also cleaned up a couple things in the health code.